### PR TITLE
Add configurable workflow question counts

### DIFF
--- a/.spec/README.md
+++ b/.spec/README.md
@@ -2,6 +2,13 @@
 
 This directory contains feature specifications and related artifacts for spec-driven development workflow.
 
+## Purpose
+
+Spec-driven development guides AI code generation through structured specifications, leading to more successful implementations. These artifacts help with feature iteration, understanding implementation decisions, and replicating similar work.
+
+### No Maintenance
+Specs are point-in-time artifacts - they are not maintained or used in automation outside of building features. Specs are not expected to be updated to reflect changes in a feature post-implementation.
+
 ## Getting Started
 
 1. Use the Claude Code command "/specify" to begin feature specification
@@ -24,7 +31,7 @@ $ claude
 ### Continue working on an existing feature:
 ```
 $ claude  
-> /specify continue to the implementation planning phase
+> /specify continue to where we left off for the user authentication feature
 ```
 
 For more information, see the main project README.md.

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,38 +1,18 @@
 package assets
 
-import (
-	"embed"
-	"io/fs"
-)
+import "embed"
 
-//go:embed templates/*
-var templatesFS embed.FS
+//go:embed commands
+var CommandsFS embed.FS
 
-//go:embed commands/*
-var commandsFS embed.FS
+//go:embed agents
+var AgentsFS embed.FS
 
-//go:embed agents/*
-var agentsFS embed.FS
+//go:embed templates
+var TemplatesFS embed.FS
 
 //go:embed spec-readme.md
-var specReadmeContent embed.FS
+var SpecReadmeContent embed.FS
 
-// GetTemplatesFS returns the embedded templates filesystem
-func GetTemplatesFS() fs.FS {
-	return templatesFS
-}
-
-// GetCommandsFS returns the embedded commands filesystem  
-func GetCommandsFS() fs.FS {
-	return commandsFS
-}
-
-// GetAgentsFS returns the embedded agents filesystem
-func GetAgentsFS() fs.FS {
-	return agentsFS
-}
-
-// GetSpecReadme returns the content of the spec README file
-func GetSpecReadme() ([]byte, error) {
-	return specReadmeContent.ReadFile("spec-readme.md")
-}
+//go:embed config
+var ConfigFS embed.FS

--- a/assets/commands/specify.md
+++ b/assets/commands/specify.md
@@ -3,6 +3,16 @@
 ## Summary
 Guide the user through a comprehensive spec-driven development workflow for feature requirements gathering and implementation planning based on $ARGUMENTS using the specware tool.
 
+## Configuration
+
+Before starting the workflow, read the configuration from `.spec/config.json` to determine the number of questions to ask at each step:
+- `requirements.discovery_questions`: Number of discovery questions during requirements gathering (default: 5)
+- `requirements.expert_questions`: Number of expert questions during requirements analysis (default: 4)
+- `implementation.plan_questions`: Number of questions during implementation planning (default: 5)
+- `implementation.testing_questions`: Number of testing questions during testing analysis (default: 2)
+
+If the config file doesn't exist or can't be read, use the default values shown above.
+
 ## Workflow
 
 ### Pre: Assess Input
@@ -25,7 +35,8 @@ Guide the user through generating a requirements specification.
 - Use `specware feature update-state <short-name> "Requirements Gathering"`
 - Fill in the basic sections and metadata of the requirements spec
 - Create initial content in both `requirements.md` and `context-requirements.md`
-- Generate the five most important yes/no questions to understand the problem space:
+- Read the configuration from `.spec/config.json` to determine the number of discovery questions to ask
+- Generate the configured number of most important yes/no questions to understand the problem space (default: 5):
   - Questions informed by codebase structure
   - Questions about user interactions and workflows
   - Questions about similar features users currently use
@@ -44,7 +55,8 @@ Guide the user through generating a requirements specification.
 #### Step 4: Expert Requirements Questions
 - Use `specware feature update-state <short-name> "Requirements Expert Q&A"`
 - Now you are an expert on the codebase, a senior developer with the right knowledge.
-- Write the top 3-5 most important questions yes/no questions to `context-requirements.md`
+- Read the configuration from `.spec/config.json` to determine the number of expert questions to ask
+- Write the configured number of most important yes/no questions to `context-requirements.md` (default: 4):
   - Questions about external integrations or third-party services
   - Questions about access control
   - Questions about performance or scale expectations
@@ -130,7 +142,8 @@ When the user is ready for implementation planning:
 
 #### Step 3: Implementation Plan Q&A
 - Use `specware feature update-state <short-name> "Implementation Plan Q&A"`
-- Generate the five most important yes/no questions to understand technical implementation details:
+- Read the configuration from `.spec/config.json` to determine the number of implementation plan questions to ask
+- Generate the configured number of most important yes/no questions to understand technical implementation details (default: 5):
   - Questions about best practices or patterns to follow
   - Questions about packaging and file structure
   - Questions about data model details and conventions
@@ -143,7 +156,8 @@ When the user is ready for implementation planning:
 
 #### Step 4: Testing Q&A
 - Review what testing exists for similar features and determine what unit, integration, and e2e tests may be necessary for this feature.
-- Generate at least 2 of the most important yes/no questions to clarify testing requirements, considering:
+- Read the configuration from `.spec/config.json` to determine the number of testing questions to ask
+- Generate the configured number of most important yes/no questions to clarify testing requirements (default: 2), considering:
   - Questions about unit, integration, and e2e testing
   - Questions about when to write which tests (Test Driven Development for example)
   - Questions about how to run specific tests if required and unclear

--- a/assets/config/config.json
+++ b/assets/config/config.json
@@ -1,0 +1,10 @@
+{
+  "requirements": {
+    "discovery_questions": 5,
+    "expert_questions": 4
+  },
+  "implementation": {
+    "plan_questions": 5,
+    "testing_questions": 2
+  }
+}


### PR DESCRIPTION
## Summary
Add configuration system for customizable question counts in each workflow phase

## Changes  
- Add config.json with configurable question counts for workflow phases
- Update /specify command to read configuration and use dynamic question counts
- Refactor asset management for cleaner code architecture
- Enhance documentation with purpose and maintenance guidance

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Enable customizable question counts in the spec-driven workflow by embedding a config.json file, updating the specify command to consume these settings, refactoring asset handling to streamline embedded filesystem usage, and enriching documentation with configuration and purpose details.

New Features:
- Add embedded config directory with config.json to allow customizing the number of questions per workflow phase
- Update the /specify command to read question-count settings from .spec/config.json and apply them dynamically

Enhancements:
- Refactor asset management to use direct embedded FS variables (CommandsFS, AgentsFS, TemplatesFS, SpecReadmeContent, ConfigFS) instead of getter functions
- Extend project initialization to copy the new config assets into the .spec folder alongside existing commands, agents, and templates

Documentation:
- Enhance commands/specify.md to explain how to configure question counts and list default values for each step
- Expand .spec/README.md with a purpose section and maintenance guidance for spec artifacts